### PR TITLE
fix: 🐛 spinner during approve login

### DIFF
--- a/lib/components/Auth/Login.js
+++ b/lib/components/Auth/Login.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { View } from 'react-native'
 import Modal from 'react-native-modal'
 import { Wrap, ScrollViewWrap } from '../view/Wrapper'
+import { Spinner } from '../elements/Spinner/Spinner'
 import styled, { theme as globalTheme } from '../../theme'
 import { H3, Paragraph, Separator } from '../typography/Typography'
 import {
@@ -40,7 +41,7 @@ function Login(props) {
 
   const approve = async () => {
     updateState({ ...currentState, view: 'approving' })
-    approveLogin({
+    await approveLogin({
       connection: props.existingConnection,
       sessionId: props.sessionId,
     })
@@ -101,7 +102,14 @@ function Login(props) {
         </Wrap>
       )
     case 'approving':
-      return <Paragraph>Godkänner...</Paragraph>
+      return (
+        <Wrap>
+          <Spinner />
+          <Paragraph align="center" style={{ marginTop: 24 }}>
+            Godkänner...
+          </Paragraph>
+        </Wrap>
+      )
     case 'error':
       return (
         <Wrap>

--- a/lib/components/Auth/Scan.js
+++ b/lib/components/Auth/Scan.js
@@ -47,7 +47,7 @@ class Scan extends Component {
           <Wrap>
             <Spinner />
             <Paragraph align="center" style={{ marginTop: 24 }}>
-              Bearbeterar förfrågan...
+              Bearbetar förfrågan...
             </Paragraph>
           </Wrap>
         )

--- a/lib/services/auth.js
+++ b/lib/services/auth.js
@@ -74,7 +74,7 @@ export const approveLogin = async ({ connection, sessionId }) => {
   try {
     const login = await createLogin(connection, sessionId)
     const loginResponse = await createLoginResponse(login)
-    await axios.post(Config.OPERATOR_URL, loginResponse, {
+    return axios.post(Config.OPERATOR_URL, loginResponse, {
       headers: { 'content-type': 'application/jwt' },
     })
   } catch (error) {


### PR DESCRIPTION
to hide the fact the jws-lite sign function is painfully slow;
