### PR TITLE
feat: add loader after selecting PDS

### DIFF
--- a/lib/components/wizard/PDS.js
+++ b/lib/components/wizard/PDS.js
@@ -1,11 +1,17 @@
 import React, { Component } from 'react'
 import { Image, View } from 'react-native'
 import { H1, Paragraph } from '../typography/Typography'
+import { Wrap } from '../view/Wrapper'
 import { PrimaryButton } from '../elements/Button/Button'
+import { Spinner } from '../elements/Spinner/Spinner'
 
 import dropbox from '../../services/dropbox'
 
 export default class PDS extends Component {
+  state = {
+    loading: false,
+  }
+
   connectToDropbox = async () => {
     dropbox.once('connect', pds => {
       this.props.onConnect(pds)
@@ -15,6 +21,7 @@ export default class PDS extends Component {
   }
 
   useMem = () => {
+    this.setState(prevState => ({ ...prevState, loading: true }))
     this.props.onConnect({
       provider: 'memory',
       access_token: 'nope',
@@ -22,7 +29,14 @@ export default class PDS extends Component {
   }
 
   render() {
-    return (
+    return this.state.loading ? (
+      <Wrap>
+        <Spinner />
+        <Paragraph align="center" style={{ marginTop: 24 }}>
+          Ansluter...
+        </Paragraph>
+      </Wrap>
+    ) : (
       <>
         <H1>Lagring</H1>
         <Image


### PR DESCRIPTION
**Ticket:** [#311](https://trello.com/c/C0RRoc7X/311-add-spinner-when-selecting-a-pds)
**Intent:**

To let the user know something is actually happening, and prevent them from clicking multiple times etc.

**How to test (optional):**

Clear account. Register, select PDS, you should see a spinner.

### All of the following commands should pass.

- [x] `npm test`
- [x] `npm run lint`
