### PR TITLE
fix: 🐛 issue when starting app from URL

### DIFF
--- a/lib/components/Auth/Scan.js
+++ b/lib/components/Auth/Scan.js
@@ -12,6 +12,12 @@ class Scan extends Component {
     validated: false,
   }
 
+  componentWillMount() {
+    if (this.props.myDataUrl) {
+      this.onScanQRCode(this.props.myDataUrl)
+    }
+  }
+
   scan = () => {
     this.setState({ view: 'scan' })
   }

--- a/lib/screens/Auth/Auth.js
+++ b/lib/screens/Auth/Auth.js
@@ -5,6 +5,11 @@ import { handle } from '../../services/index'
 const AuthScreen = props => {
   const [state, setState] = useState({
     view: (props && props.view) || 'scan',
+    myDataUrl:
+      (props &&
+        props.navigation.state.params &&
+        props.navigation.state.params.myDataUrl) ||
+      null,
   })
 
   const onScan = async token => {
@@ -57,7 +62,9 @@ const AuthScreen = props => {
       )
     case 'scan':
     default:
-      return <Scan onCancel={onCancel} onScan={onScan} />
+      return (
+        <Scan onCancel={onCancel} onScan={onScan} myDataUrl={state.myDataUrl} />
+      )
   }
 }
 


### PR DESCRIPTION
**Ticket:** [#](https://trello.com/c/3FYi0YUs/310-app-does-not-send-consent-request-on-initial-open)
**Intent:**
it would show the QR code scanner the first time instead of using the url
**How to test (optional):**

On iOS, build the app on `master` and run it on your phone using xcode.
Go to Safari and browse to the cv example based on what operator you have set locally - I use CV-test since I use operator-test.

Click Login and then open on the same device. Instead of presenting the popup to accept/decline it would show the QR code scanner the first time the app is launched.

On this branch this should not happen. Other scenarios tested are then using the qr code scanner which still should work.

### All of the following commands should pass.

- [ ] `npm test`
- [ ] `npm run lint`
