### PR TITLE
fix: 🐛 ios missing aud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,9 @@ jobs:
         - bundle install
         - pod install
       script:
-        - fastlane ios_testflight
+        - |
+          echo "OPERATOR_URL=${OPERATOR_URL} DROPBOX_KEY=${PDS_KEY}" > .env
+          fastlane ios_testflight
 
     - stage: deliver
       name: "Build Docker image"


### PR DESCRIPTION
add env variables when we run the fastlane

